### PR TITLE
Fill Damiao Sub Package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5.6.0
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install Dependencies
         run: |

--- a/openarm/damiao/__init__.py
+++ b/openarm/damiao/__init__.py
@@ -226,6 +226,29 @@ def control_mit_command(
     )
 
 
+def control_pos_vel_command(
+    slave_id: int,
+    pos: float,
+    vel: float,
+) -> can.Message:
+    """Create a CAN message to control a Damiao motor in position and velocity mode.
+
+    Args:
+        slave_id (int): Slave ID for the target motor.
+        pos (float): Desired position (radians).
+        vel (float): Desired velocity (radians/second).
+
+    Returns:
+        can.Message: A CAN message containing position and velocity control parameters.
+
+    """
+    return can.Message(
+        arbitration_id=0x100 + slave_id,
+        data=[*struct.pack("<f", float(pos)), *struct.pack("<f", float(vel))],
+        is_extended_id=False,
+    )
+
+
 def read_register_command(slave_id: int, address: RegisterAddress) -> can.Message:
     """Create a CAN message to read a specific register from a Damiao motor.
 
@@ -425,6 +448,7 @@ __all__ = [
     "StateResponse",
     "UnknownResponse",
     "control_mit_command",
+    "control_pos_vel_command",
     "decode_response",
     "disable_command",
     "enable_command",

--- a/openarm/damiao/__init__.py
+++ b/openarm/damiao/__init__.py
@@ -107,6 +107,15 @@ class RegisterAddress(IntEnum):
     XOUT = 81
 
 
+class ControlMode(IntEnum):
+    """Enumeration of Damiao motor control mode."""
+
+    MIT = 1
+    POS_VEL = 2
+    VEL = 3
+    POS_FORCE = 4
+
+
 def enable_command(slave_id: int) -> can.Message:
     """Create a CAN message to enable a Damiao motor.
 
@@ -388,6 +397,20 @@ def write_register_command(
     )
 
 
+def set_control_mode_command(slave_id: int, mode: ControlMode) -> can.Message:
+    """Create a CAN message to set the control mode of a Damiao motor.
+
+    Args:
+        slave_id (int): Slave ID of the target motor.
+        mode (ControlMode): The control mode to set.
+
+    Returns:
+        can.Message: A CAN message that, when sent, sets the motor's control mode.
+
+    """
+    return write_register_command(slave_id, RegisterAddress.CTRL_MODE, mode)
+
+
 class Response:
     """Base class for responses from Damiao motors."""
 
@@ -520,6 +543,7 @@ def decode_response(msg: can.Message) -> Response:
 
 
 __all__ = [
+    "ControlMode",
     "MotorState",
     "MotorType",
     "RegisterAddress",
@@ -536,6 +560,7 @@ __all__ = [
     "enable_command",
     "read_register_command",
     "refresh_command",
+    "set_control_mode_command",
     "set_zero_command",
     "write_register_command",
 ]

--- a/openarm/damiao/__init__.py
+++ b/openarm/damiao/__init__.py
@@ -1,12 +1,68 @@
 """Damiao sub-package for OpenArm.
 
 This module provides helper functions to construct CAN messages
-for enabling and disabling Damiao motors.
+for enabling and disabling Damiao motors, reading registers, and
+decoding responses from the motors.
 """
+
+import struct
+from enum import IntEnum
 
 import can
 
 __version__ = "0.1.0"
+
+_READ_REGISTER_CODE = 0x33
+
+
+class RegisterAddress(IntEnum):
+    """Enumeration of Damiao motor register addresses."""
+
+    UV_VALUE = 0
+    KT_VALUE = 1
+    OT_VALUE = 2
+    OC_VALUE = 3
+    ACC = 4
+    DEC = 5
+    MAX_SPD = 6
+    MST_ID = 7
+    ESC_ID = 8
+    TIMEOUT = 9
+    CTRL_MODE = 10
+    DAMP = 11
+    INERTIA = 12
+    HW_VER = 13
+    SW_VER = 14
+    SN = 15
+    NPP = 16
+    RS = 17
+    LS = 18
+    FLUX = 19
+    GR = 20
+    PMAX = 21
+    VMAX = 22
+    TMAX = 23
+    I_BW = 24
+    KP_ASR = 25
+    KI_ASR = 26
+    KP_APR = 27
+    KI_APR = 28
+    OV_VALUE = 29
+    GREF = 30
+    DETA = 31
+    V_BW = 32
+    IQ_C1 = 33
+    VL_C1 = 34
+    CAN_BAR = 35
+    SUB_VER = 36
+    U_OFF = 50
+    V_OFF = 51
+    K1 = 52
+    K2 = 53
+    M_OFF = 54
+    DIR = 55
+    P_M = 80
+    XOUT = 81
 
 
 def enable_command(slave_id: int) -> can.Message:
@@ -43,4 +99,116 @@ def disable_command(slave_id: int) -> can.Message:
     )
 
 
-__all__ = ["disable_command", "enable_command"]
+def read_register_command(slave_id: int, address: RegisterAddress) -> can.Message:
+    """Create a CAN message to read a specific register from a Damiao motor.
+
+    Args:
+        slave_id (int): Slave ID for the target motor.
+        address (RegisterAddress): The register address to read.
+
+    Returns:
+        can.Message: A CAN message that, when sent, requests the register value.
+
+    """
+    return can.Message(
+        arbitration_id=0x7FF,
+        data=[
+            slave_id & 0xFF,
+            (slave_id >> 8) & 0xFF,
+            _READ_REGISTER_CODE,
+            address,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+        ],
+        is_extended_id=False,
+    )
+
+
+class Response:
+    """Base class for responses from Damiao motors."""
+
+    def __init__(self, msg: can.Message) -> None:
+        """Initialize a Response object from a CAN message.
+
+        Args:
+            msg (can.Message): The CAN message received from the motor.
+
+        """
+        self.master_id = msg.arbitration_id
+
+
+class UnknownResponse(Response):
+    """Represents an unknown response from a Damiao motor."""
+
+    def __init__(self, msg: can.Message) -> None:
+        """Initialize an UnknownResponse object from a CAN message.
+
+        Args:
+            msg (can.Message): The CAN message received from the motor.
+
+        """
+        super().__init__(msg)
+        self.data = msg.data
+
+
+class RegisterResponse(Response):
+    """Represents a response containing register data from a Damiao motor."""
+
+    def __init__(self, msg: can.Message) -> None:
+        """Initialize a RegisterResponse object from a CAN message.
+
+        Args:
+            msg (can.Message): The CAN message received from the motor.
+
+        """
+        super().__init__(msg)
+        self.slave_id = msg.data[0] | (msg.data[1] << 8)
+        self.register = RegisterAddress(msg.data[3])
+        self.data = bytes(msg.data[4:8])
+
+    def as_int(self) -> int:
+        """Interpret the register data as a 32-bit unsigned integer.
+
+        Returns:
+            int: The register value as an integer.
+
+        """
+        return struct.unpack("<I", self.data)[0]
+
+    def as_float(self) -> float:
+        """Interpret the register data as a 32-bit float.
+
+        Returns:
+            float: The register value as a float.
+
+        """
+        return struct.unpack("<f", self.data)[0]
+
+
+def decode_response(msg: can.Message) -> Response:
+    """Decode a CAN message into the appropriate Response subclass.
+
+    Args:
+        msg (can.Message): The CAN message to decode.
+
+    Returns:
+        Response: Either a RegisterResponse or UnknownResponse depending on the command.
+
+    """
+    if msg.data[2] == _READ_REGISTER_CODE:
+        return RegisterResponse(msg)
+    return UnknownResponse(msg)
+
+
+__all__ = [
+    "RegisterAddress",
+    "RegisterResponse",
+    "Response",
+    "UnknownResponse",
+    "decode_response",
+    "disable_command",
+    "enable_command",
+    "read_register_command",
+]

--- a/openarm/damiao/__init__.py
+++ b/openarm/damiao/__init__.py
@@ -1,3 +1,46 @@
-"""Damiao sub-package for OpenArm."""
+"""Damiao sub-package for OpenArm.
+
+This module provides helper functions to construct CAN messages
+for enabling and disabling Damiao motors.
+"""
+
+import can
 
 __version__ = "0.1.0"
+
+
+def enable_command(slave_id: int) -> can.Message:
+    """Create a CAN message to enable a Damiao motor.
+
+    Args:
+        slave_id (int): Slave ID for the target motor.
+
+    Returns:
+        can.Message: A CAN message that, when sent, enables the motor.
+
+    """
+    return can.Message(
+        arbitration_id=slave_id,
+        data=[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFC],
+        is_extended_id=False,
+    )
+
+
+def disable_command(slave_id: int) -> can.Message:
+    """Create a CAN message to disable a Damiao motor.
+
+    Args:
+        slave_id (int): Slave ID for the target motor.
+
+    Returns:
+        can.Message: A CAN message that, when sent, disables the motor.
+
+    """
+    return can.Message(
+        arbitration_id=slave_id,
+        data=[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFD],
+        is_extended_id=False,
+    )
+
+
+__all__ = ["disable_command", "enable_command"]

--- a/openarm/damiao/__init__.py
+++ b/openarm/damiao/__init__.py
@@ -267,6 +267,27 @@ def control_pos_vel_command(
     )
 
 
+def control_vel_command(
+    slave_id: int,
+    vel: float,
+) -> can.Message:
+    """Create a CAN message to control a Damiao motor in velocity mode.
+
+    Args:
+        slave_id (int): Slave ID for the target motor.
+        vel (float): Desired velocity (radians/second).
+
+    Returns:
+        can.Message: A CAN message containing velocity control parameters.
+
+    """
+    return can.Message(
+        arbitration_id=0x200 + slave_id,
+        data=[*struct.pack("<f", float(vel)), 0x00, 0x00, 0x00, 0x00],
+        is_extended_id=False,
+    )
+
+
 def read_register_command(slave_id: int, address: RegisterAddress) -> can.Message:
     """Create a CAN message to read a specific register from a Damiao motor.
 
@@ -467,6 +488,7 @@ __all__ = [
     "UnknownResponse",
     "control_mit_command",
     "control_pos_vel_command",
+    "control_vel_command",
     "decode_response",
     "disable_command",
     "enable_command",

--- a/openarm/damiao/__init__.py
+++ b/openarm/damiao/__init__.py
@@ -141,6 +141,24 @@ def disable_command(slave_id: int) -> can.Message:
     )
 
 
+def set_zero_command(slave_id: int) -> can.Message:
+    """Create a CAN message to set the current position of a Damiao motor as zero.
+
+    Args:
+        slave_id (int): The slave ID of the target motor.
+
+    Returns:
+        can.Message: A CAN message that, when sent, sets the motor's current position
+            as its zero reference.
+
+    """
+    return can.Message(
+        arbitration_id=slave_id,
+        data=[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE],
+        is_extended_id=False,
+    )
+
+
 def refresh_command(slave_id: int) -> can.Message:
     """Create a CAN message to refresh the state of a Damiao motor.
 
@@ -454,5 +472,6 @@ __all__ = [
     "enable_command",
     "read_register_command",
     "refresh_command",
+    "set_zero_command",
     "write_register_command",
 ]

--- a/openarm/damiao/__main__.py
+++ b/openarm/damiao/__main__.py
@@ -29,6 +29,7 @@ from . import (
     enable_command,
     read_register_command,
     refresh_command,
+    set_zero_command,
     write_register_command,
 )
 
@@ -41,6 +42,11 @@ def _enable(args: argparse.Namespace) -> None:
 def _disable(args: argparse.Namespace) -> None:
     with can.Bus(channel=args.iface, interface="socketcan") as bus:
         bus.send(disable_command(args.slave_id))
+
+
+def _set_zero(args: argparse.Namespace) -> None:
+    with can.Bus(channel=args.iface, interface="socketcan") as bus:
+        bus.send(set_zero_command(args.slave_id))
 
 
 def _refresh(args: argparse.Namespace) -> None:
@@ -120,6 +126,11 @@ def _main() -> None:
     disable_parser.add_argument("--iface", default="can0", help="CAN interface to use")
     disable_parser.add_argument("slave_id", type=int, help="Slave ID of the motor")
     disable_parser.set_defaults(func=_disable)
+
+    disable_parser = subparsers.add_parser("set_zero", help="Set motor zero position")
+    disable_parser.add_argument("--iface", default="can0", help="CAN interface to use")
+    disable_parser.add_argument("slave_id", type=int, help="Slave ID of the motor")
+    disable_parser.set_defaults(func=_set_zero)
 
     refresh_parser = subparsers.add_parser("refresh", help="Refresh motor")
     refresh_parser.add_argument("--iface", default="can0", help="CAN interface to use")

--- a/openarm/damiao/__main__.py
+++ b/openarm/damiao/__main__.py
@@ -1,0 +1,52 @@
+"""Command-line interface for controlling Damiao motors over CAN.
+
+This module provides a CLI to send enable or disable commands to
+Damiao motors via a SocketCAN interface.
+
+Commands:
+    enable   Enable the specified motor.
+    disable  Disable the specified motor.
+
+Examples:
+    python -m openarm.damiao enable --iface can0 1
+    python -m openarm.damiao disable 2
+
+"""
+
+import argparse
+
+import can
+
+from . import disable_command, enable_command
+
+
+def _enable(args: argparse.Namespace) -> None:
+    with can.Bus(channel=args.iface, interface="socketcan") as bus:
+        bus.send(enable_command(args.slave_id))
+
+
+def _disable(args: argparse.Namespace) -> None:
+    with can.Bus(channel=args.iface, interface="socketcan") as bus:
+        bus.send(disable_command(args.slave_id))
+
+
+def _main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    enable_parser = subparsers.add_parser("enable", help="Enable motor")
+    enable_parser.add_argument("--iface", default="can0", help="CAN interface to use")
+    enable_parser.add_argument("slave_id", type=int, help="Slave ID of the motor")
+    enable_parser.set_defaults(func=_enable)
+
+    disable_parser = subparsers.add_parser("disable", help="Disable motor")
+    disable_parser.add_argument("--iface", default="can0", help="CAN interface to use")
+    disable_parser.add_argument("slave_id", type=int, help="Slave ID of the motor")
+    disable_parser.set_defaults(func=_disable)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    _main()

--- a/openarm/damiao/__main__.py
+++ b/openarm/damiao/__main__.py
@@ -23,6 +23,7 @@ from . import (
     RegisterResponse,
     StateResponse,
     control_mit_command,
+    control_pos_force_command,
     control_pos_vel_command,
     control_vel_command,
     decode_response,
@@ -90,6 +91,13 @@ def _control_pos_vel(args: argparse.Namespace) -> None:
 def _control_vel(args: argparse.Namespace) -> None:
     with can.Bus(channel=args.iface, interface="socketcan") as bus:
         bus.send(control_vel_command(args.slave_id, args.vel))
+
+
+def _control_pos_force(args: argparse.Namespace) -> None:
+    with can.Bus(channel=args.iface, interface="socketcan") as bus:
+        bus.send(
+            control_pos_force_command(args.slave_id, args.pos, args.vel, args.i_norm)
+        )
 
 
 def _register_read(args: argparse.Namespace) -> None:
@@ -177,6 +185,22 @@ def _main() -> None:
     vel_parser.add_argument("slave_id", type=int, help="Slave ID of the motor")
     vel_parser.add_argument("vel", type=float, help="Desired velocity (radians/second)")
     vel_parser.set_defaults(func=_control_vel)
+
+    pos_force_parser = control_subparsers.add_parser(
+        "pos_force", help="Control motor in force-position hybrid mode"
+    )
+    pos_force_parser.add_argument(
+        "--iface", default="can0", help="CAN interface to use"
+    )
+    pos_force_parser.add_argument("slave_id", type=int, help="Slave ID of the motor")
+    pos_force_parser.add_argument("pos", type=float, help="Desired position (radians)")
+    pos_force_parser.add_argument(
+        "vel", type=float, help="Desired velocity (radians/second)"
+    )
+    pos_force_parser.add_argument(
+        "i_norm", type=float, help="Desired normalized current (0-1)"
+    )
+    pos_force_parser.set_defaults(func=_control_pos_force)
 
     register_parser = subparsers.add_parser("register", help="Manage motor register")
     register_subparsers = register_parser.add_subparsers(dest="command", required=True)

--- a/openarm/damiao/__main__.py
+++ b/openarm/damiao/__main__.py
@@ -23,6 +23,7 @@ from . import (
     RegisterResponse,
     StateResponse,
     control_mit_command,
+    control_pos_vel_command,
     decode_response,
     disable_command,
     enable_command,
@@ -72,6 +73,11 @@ def _control_mit(args: argparse.Namespace) -> None:
                 args.tau,
             )
         )
+
+
+def _control_pos_vel(args: argparse.Namespace) -> None:
+    with can.Bus(channel=args.iface, interface="socketcan") as bus:
+        bus.send(control_pos_vel_command(args.slave_id, args.pos, args.vel))
 
 
 def _register_read(args: argparse.Namespace) -> None:
@@ -135,6 +141,17 @@ def _main() -> None:
     mit_parser.add_argument("dq", type=float, help="Desired velocity (radians/second)")
     mit_parser.add_argument("tau", type=float, help="Desired torque (Nm)")
     mit_parser.set_defaults(func=_control_mit)
+
+    pos_vel_parser = control_subparsers.add_parser(
+        "pos_vel", help="Control motor in position and velocity mode"
+    )
+    pos_vel_parser.add_argument("--iface", default="can0", help="CAN interface to use")
+    pos_vel_parser.add_argument("slave_id", type=int, help="Slave ID of the motor")
+    pos_vel_parser.add_argument("pos", type=float, help="Desired position (radians)")
+    pos_vel_parser.add_argument(
+        "vel", type=float, help="Desired velocity (radians/second)"
+    )
+    pos_vel_parser.set_defaults(func=_control_pos_vel)
 
     register_parser = subparsers.add_parser("register", help="Manage motor register")
     register_subparsers = register_parser.add_subparsers(dest="command", required=True)

--- a/openarm/damiao/__main__.py
+++ b/openarm/damiao/__main__.py
@@ -19,6 +19,7 @@ import sys
 import can
 
 from . import (
+    MotorType,
     RegisterResponse,
     StateResponse,
     decode_response,
@@ -46,6 +47,9 @@ def _refresh(args: argparse.Namespace) -> None:
         for msg in bus:
             res = decode_response(msg)
             if isinstance(res, StateResponse) and res.master_id == args.master_id:
+                if args.motor_type is not None:
+                    res = res.as_motor(MotorType(args.motor_type))
+
                 sys.stdout.write(f"q: {res.q}\n")
                 sys.stdout.write(f"dq: {res.dq}\n")
                 sys.stdout.write(f"tau: {res.tau}\n")
@@ -97,6 +101,7 @@ def _main() -> None:
 
     refresh_parser = subparsers.add_parser("refresh", help="Refresh motor")
     refresh_parser.add_argument("--iface", default="can0", help="CAN interface to use")
+    refresh_parser.add_argument("--motor-type", default=None, help="The motor type")
     refresh_parser.add_argument("master_id", type=int, help="Master ID of the motor")
     refresh_parser.add_argument("slave_id", type=int, help="Slave ID of the motor")
     refresh_parser.set_defaults(func=_refresh)

--- a/openarm/damiao/__main__.py
+++ b/openarm/damiao/__main__.py
@@ -24,6 +24,7 @@ from . import (
     StateResponse,
     control_mit_command,
     control_pos_vel_command,
+    control_vel_command,
     decode_response,
     disable_command,
     enable_command,
@@ -84,6 +85,11 @@ def _control_mit(args: argparse.Namespace) -> None:
 def _control_pos_vel(args: argparse.Namespace) -> None:
     with can.Bus(channel=args.iface, interface="socketcan") as bus:
         bus.send(control_pos_vel_command(args.slave_id, args.pos, args.vel))
+
+
+def _control_vel(args: argparse.Namespace) -> None:
+    with can.Bus(channel=args.iface, interface="socketcan") as bus:
+        bus.send(control_vel_command(args.slave_id, args.vel))
 
 
 def _register_read(args: argparse.Namespace) -> None:
@@ -163,6 +169,14 @@ def _main() -> None:
         "vel", type=float, help="Desired velocity (radians/second)"
     )
     pos_vel_parser.set_defaults(func=_control_pos_vel)
+
+    vel_parser = control_subparsers.add_parser(
+        "vel", help="Control motor in velocity mode"
+    )
+    vel_parser.add_argument("--iface", default="can0", help="CAN interface to use")
+    vel_parser.add_argument("slave_id", type=int, help="Slave ID of the motor")
+    vel_parser.add_argument("vel", type=float, help="Desired velocity (radians/second)")
+    vel_parser.set_defaults(func=_control_vel)
 
     register_parser = subparsers.add_parser("register", help="Manage motor register")
     register_subparsers = register_parser.add_subparsers(dest="command", required=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,4 @@ include = ["openarm*"]
 
 [tool.ruff.lint]
 select = ["ALL"]
-ignore = ["COM812", "D203", "D213"]
+ignore = ["COM812", "D203", "D213", "PLR0913"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "openarm"
 version = "0.1.0"
 description = "A Python package for robotic arm control and automation"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 dependencies = ["python-can"]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,10 @@ version = "0.1.0"
 description = "A Python package for robotic arm control and automation"
 readme = "README.md"
 requires-python = ">=3.8"
-dependencies = ["can"]
+dependencies = ["python-can"]
+
+[project.scripts]
+damiao = "openarm.damiao.__main__:_main"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,4 @@ include = ["openarm*"]
 
 [tool.ruff.lint]
 select = ["ALL"]
-ignore = ["COM812", "D203", "D213", "PLR0913"]
+ignore = ["COM812", "D203", "D213", "PLR0913", "PLR0915"]


### PR DESCRIPTION
Fill the Damiao subpackage with CAN frame encoders/decoders and a CLI tool for controlling the Damiao motor. All functionality has been tested and works on a DM410 motor. This change also bump the minimum required Python to version 3.11 because of the need to utilize [StrEnum](https://docs.python.org/3/library/enum.html#enum.StrEnum).