### PR TITLE
Add Lefthook Configuration

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -1,0 +1,11 @@
+pre-commit:
+  piped: true
+  jobs:
+    - name: fix formatting
+      run: ruff format
+
+    - name: fix lint
+      run: ruff check --fix
+
+    - name: check diff
+      run: git diff --exit-code {staged_files}


### PR DESCRIPTION
Add Lefthook configuration for pre-commit hooks. This is optional during development — to enable it, simply install Lefthook and set up the pre-commit hooks:

```
pip install lefthook
lefthook install
```