### PR TITLE
fix endianness in damiao motor encoding

### DIFF
--- a/openarm/damiao/encoding.py
+++ b/openarm/damiao/encoding.py
@@ -338,9 +338,9 @@ async def decode_motor_state(
     message = bus.recv(master_id, timeout=0.1)
 
     # Unpack motor state response data according to protocol format
-    # Format: '<BHHBB' = little-endian: slave_id(B) + packed_data(2*H) + temps(2*B)
+    # Format: '>BHHBB' = big-endian: slave_id(B) + packed_data(2*H) + temps(2*B)
     # Reference: Motor state format in DM_CAN.py __process_packet CMD==0x11 handling
-    slave_id, word1, word2, t_mos, t_rotor = struct.unpack("<BHHBB", message.data[:7])
+    slave_id, word1, word2, t_mos, t_rotor = struct.unpack(">BHHBB", message.data[:7])
 
     # Extract packed motor state values using bit operations
     # Reference: DM_CAN.py __process_packet lines 264-266 bit unpacking

--- a/openarm/damiao/encoding.py
+++ b/openarm/damiao/encoding.py
@@ -297,7 +297,7 @@ def encode_control_mit(
     tau_uint = _float_to_uint(params.tau, -tau_max, tau_max, 12)
 
     # Pack data according to MIT control protocol bit layout
-    # Format: '<HHHH' = little-endian 4 unsigned 16-bit values with bit manipulation
+    # Format: '>HHHH' = big-endian 4 unsigned 16-bit values with bit manipulation
     # Reference: DM_CAN.py controlMIT data_buf packing lines 114-121
     # Pack as: q(16-bit), dq(12-bit)|kp_high(4-bit), kp_low(8-bit)|kd_high(8-bit),
     # kd_low(4-bit)|tau(12-bit)
@@ -306,7 +306,7 @@ def encode_control_mit(
     word3 = (kp_uint & 0xFF) | ((kd_uint & 0xFF0) << 4)  # kp_low(8) + kd_high(8)
     word4 = ((kd_uint & 0xF) << 12) | (tau_uint & 0xFFF)  # kd_low(4) + tau(12)
 
-    data = struct.pack("<HHHH", word1, word2, word3, word4)
+    data = struct.pack(">HHHH", word1, word2, word3, word4)
 
     # Send directly to motor's slave ID for MIT control
     # Reference: DM_CAN.py __send_data call with DM_Motor.SlaveID in controlMIT


### PR DESCRIPTION
Fix `decode_motor_state` and `encode_control_mit` functions in `damiao` package which should use big-endian instead of little-endian.