### PR TITLE
Update `setup_can.sh` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ OpenArm provides multiple tools for controlling and monitoring Damiao servo moto
 Before using any motor control commands, you need to set up the CAN interfaces:
 
 ```bash
-sudo ./scripts/setup_can.sh
+sudo ./scripts/setup_can.sh left_arm right_arm
 ```
 
-This script configures the CAN devices with the proper interface names (`leader_left`, `leader_right`, `follower_left`, `follower_right`) and sets the bitrate to 1 Mbps. You only need to run this script once—afterwards, whenever the CAN devices are replugged or the computer is restarted, they will be set up automatically.
+This script configures the CAN devices with the specified interface names and sets the bitrate to 1 Mbps. Interface names are provided as command-line arguments. You only need to run this script once—afterwards, whenever the CAN devices are replugged or the computer is restarted, they will be set up automatically.
 
 ### Zero Position Calibration
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ OpenArm provides multiple tools for controlling and monitoring Damiao servo moto
 
 ### CAN Interface Setup (Linux only)
 
-Before using any motor control commands, set up the CAN interfaces:
+Before using any motor control commands, you need to set up the CAN interfaces:
 
 ```bash
 sudo ./scripts/setup_can.sh
 ```
 
-This script configures the CAN devices with proper interface names (leader_left, leader_right, follower_left, follower_right) and sets the bitrate to 1 Mbps.
+This script configures the CAN devices with the proper interface names (`leader_left`, `leader_right`, `follower_left`, `follower_right`) and sets the bitrate to 1 Mbps. You only need to run this script once—afterwards, whenever the CAN devices are replugged or the computer is restarted, they will be set up automatically.
 
 ### Zero Position Calibration
 

--- a/scripts/setup_can.sh
+++ b/scripts/setup_can.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 
 # =============================================================================
-# Usage: sudo ./enable_can.sh
+# Usage: sudo ./setup_can.sh
 #
 # Description:
-#   This script enables four CAN devices (leader_left, leader_right,
-#   follower_left, and follower_right) with a fixed bitrate (1 Mbps) and
-#   ensures they always have consistent interface names across reboots or
-#   replugging. If no udev rule exists yet, the script will detect the device
-#   on plug-in, rename it, and append the rule to
+#   This script configures four CAN devices (leader_left, leader_right,
+#   follower_left, and follower_right) using systemd-networkd with a fixed
+#   bitrate (1 Mbps) and ensures they always have consistent interface names
+#   across reboots or replugging. If no udev rule exists yet, the script will
+#   detect the device on plug-in, rename it, and append the rule to
 #   /etc/udev/rules.d/90-can.rules.
 #
 # Requirements:
 #   - Must be run as root
-#   - iproute2 package (for `ip link`)
+#   - systemd-networkd service
 #   - udevadm available on the system
 #
 # Behavior:
@@ -22,12 +22,12 @@
 #   3. Detects the device, renames it to the expected interface name, and
 #      writes a persistent udev rule based on the device serial number.
 #   4. Reloads and triggers udev to apply the new rule.
-#   5. Configures the CAN interface with bitrate 1000000 (1 Mbps) and brings
-#      it up.
+#   5. Creates systemd network configuration files for each CAN interface
+#      with bitrate 1000000 (1 Mbps) and enables systemd-networkd.
 #
 # Notes:
 #   - Once rules are written, future runs won’t prompt for plugging in devices.
-#   - To reset, remove /etc/udev/rules.d/90-can.rules and re-run the script.
+#   - To reset, remove /etc/udev/rules.d/90-can.rules and systemd network files.
 # =============================================================================
 
 set -e
@@ -37,7 +37,7 @@ if [[ $EUID -ne 0 ]]; then
   exit 1
 fi
 
-function enable_can {
+function setup_can {
   if ! ip link show "$1" &>/dev/null; then
     echo "→ Please plug in CAN device..."
 
@@ -70,7 +70,7 @@ function enable_can {
         serial)
           if [[ "$line" =~ ID_SERIAL_SHORT= ]]; then
             serial=$(echo "$line" | cut -d= -f2)
-            echo "→ CAN device detected: $interface ($serial)"
+            echo "→ CAN device detected: $interface [Serial: $serial]"
 
             echo "→ Renaming interface: $interface → $1"
             ip link set "$interface" name "$1"
@@ -94,23 +94,31 @@ function enable_can {
     done
   fi
 
-  echo "→ Enabling interface: $1"
-  ip link set "$1" down
-  ip link set "$1" type can bitrate 1000000
-  ip link set "$1" up
+  echo "→ Updating systemd-networkd configuration"
+  cat > "/etc/systemd/network/10-${1//_/-}.network" << EOF
+[Match]
+Name=$1
+
+[CAN]
+BitRate=1000000
+EOF
+
+  echo "→ Enabling systemd-networkd"
+  systemctl enable systemd-networkd
+  systemctl restart systemd-networkd
 }
 
 echo "[LEADER LEFT]"
-enable_can leader_left
+setup_can leader_left
 
 echo ""
 echo "[LEADER RIGHT]"
-enable_can leader_right
+setup_can leader_right
 
 echo ""
 echo "[FOLLOWER LEFT]"
-enable_can follower_left
+setup_can follower_left
 
 echo ""
 echo "[FOLLOWER RIGHT]"
-enable_can follower_right
+setup_can follower_right


### PR DESCRIPTION
Update the `setup_can.sh` script to:
- Automatically configure baudrate and enable CAN interface on plug in.
- Pass arguments to specify CAN interface name that need to set up.