### PR TITLE
Refactoring the Getting Started Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,199 @@
-# OpenArm
+# Anvil's OpenArm Experimental Testing Tools
 
-A Python package for robotic arm control and automation.
+This repository contains a variety of python scripts and debugging tools for validating Anvil's OpenArm hardware platform. Please note that this code is very experimental.
 
-## Installation
+As this code is still experimental, there will be breaking changes, and is not meant for production use cases.
 
-### Prerequisites
+For commercial use cases and customers, Anvil Robotics is developing a high performance robot control and human demonstration data collection suite (early-access in Dec 2025). Feel free to reach out to `<tbd>@anvil.bot`, if you're interested.
+
+## Prerequisites
 
 - Python 3.11 or higher
+- Ubuntu 24.04 LTS
+- An Anvil OpenArm Leader or Follower ([See Anvil Store](https://shop.anvil.bot/)), fully assembled and wired ([see Anvil's hardware assembly guide](https://www.notion.so/anvil-robotics/Anvil-s-OpenArm-Getting-Started-2025Q4-HW-Batch-2948f2efe5658066bac0daa9de065f54)).
 
-### Setup
+*(While the code will likely run on other platforms, your mileage may vary)*
 
-1. **Create a virtual environment** (recommended):
+## Setup
 
-   ```bash
-   # Using venv
-   python -m venv .venv
-   source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+### Getting the Code
+```bash
+git https://github.com/anvil-robotics/openarm.git
+cd openarm
+# <or>
+git git@github.com:anvil-robotics/openarm.git
+cd openarm
+```
 
-   # Or using conda/mamba
-   conda create -n openarm python=3.11
-   conda activate openarm
-   ```
+### Setting up the SW Environment
+#### Option 1: Setting up a Python Virtual Environment (recommended) ####
+Install Python virtual environment with:
 
-2. **Install OpenArm in development mode**:
+```bash
+sudo apt install python3-venv
+```
 
-   ```bash
-   pip install -e .
-   ```
+Create and activate a new virtual environment:
 
-   This installs all required dependencies including:
-   - `python-can` for CAN bus communication
-   - `ikpy` for inverse kinematics
-   - `mujoco` for physics simulation
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+```
 
-## Usage
+Install the project dependencies:
 
-OpenArm provides multiple tools for controlling and monitoring Damiao servo motors. All commands work with any CAN interface and automatically detect available motor configurations.
+```bash
+pip install -e .
+```
+
+Each time you open a new terminal, navigate to inside the `openarm` directory and reactivate the virtual environment with the following:
+
+> ```bash
+> source .venv/bin/activate
+> ```
+
+
+#### Option 2: Using VSCode+DevContainer ####
+If you are already familiar [VSCode and devcontainers](https://code.visualstudio.com/docs/devcontainers/containers), you can simply open the cloned openarm folder and VSCode will detect the [.devcontainer/devcontainer.json](.devcontainer/devcontainer.json) file.
+
+
+### Configuring USB-CAN Devices (udev rules)
+Each OpenArm uses 2x [Canable-style](https://canable.io/) USB-to-CAN devices (one for the left arm and one for the right arm). Each device is pre-flashed with [Candlelight firmware](https://github.com/normaldotcom/candleLight_fw). These devices are automatically detected and enumerated by the Linux host when plugged in. But, by default, the device's name that shows up in Linux depends on the order in which devices are plugged in & detected by the host. So, without any additional setup, it becomes extremely easy to accidentally swap commands between the left and right arms.
+
+#### Option 1: Script-Guided udev setup (recommended) ####
+Download and run this setup script to assign persistent names to the USB-CAN devices (based on their unique serial numbers) and bring them online automatically:
+
+```bash
+curl -L -o setup_can.sh https://gist.githubusercontent.com/threeal/f9e982150d3a1836c71b274561044549/raw/ba15c387c4c75565370f6739bcaa25ba8bddfa9a/setup_can.sh
+# Run the following, if you are connecting a leader+follower pair
+sudo bash setup_can.sh leader_l leader_r follower_l follower_r
+# Run the following, if you are connecting a single robot
+sudo bash setup_can.sh robot_l robot_r
+```
+
+The script will guide you through plugging in four (or two) USB-CAN devices: two for the leader arms and two for the follower arms. Each argument corresponds resulting device names, and the order they are should be connected.
+
+#### Option 2: Manual udev setup
+For more complex or especially unique setups, you can manually create & install your own udev rules. There are lots of online resources describing udev, and i2rt has an [example](https://github.com/i2rt-robotics/i2rt/blob/main/doc/set_persist_id_socket_can.md) of what this could look like as well.
+
+## Running Anvil's Experimental Tools
+
+### Individually Testing Every Motor (Hello World)
+
+The following instructions validate that every motor is functional and communicating as expected: See [motor-testing.md](motor-testing.md).
+
+### Motor Monitoring
+
+Monitor motor angles in real-time across all detected CAN buses:
+
+```bash
+# Monitor all motors (passive mode - motors disabled)
+python -m openarm.damiao.monitor
+
+# Specify custom CAN interface
+python -m openarm.damiao.monitor --interface leader_l
+```
+
+### Direct Motor Control
+
+Low-level control of individual motors for testing and debugging:
+
+```bash
+# Enable a motor
+python -m openarm.damiao enable --motor-type DM4310 --iface can0 1 1
+
+# Set MIT Mode and Command motor with MIT parameters
+python -m openarm.damiao param set --motor-type DM8009 --iface can0 1 17 control_mode 2
+python -m openarm.damiao control mit --motor-type DM4310 --iface can0 1 1 50 0.3 0 0 0  # kp kd q dq tau
+
+# Set PosVel control mode and Command motor with PosVel command
+python -m openarm.damiao param set --motor-type DM8009 --iface can0 1 17 control_mode 1
+python -m openarm.damiao control pos_vel --motor-type DM4310 --iface can0 1 1 1.57 2.0  # position(rad) velocity(rad/s)
+
+# Get motor status
+python -m openarm.damiao refresh --motor-type DM4310 --iface can0 1 1
+
+# Get motor parameters
+python -m openarm.damiao param get --motor-type DM4310 --iface can0 1 1 over_voltage
+
+# Disable motor safely
+python -m openarm.damiao disable --motor-type DM4310 --iface can0 1 1
+```
+
+**Common Arguments:**
+
+- `--motor-type TYPE`: Motor type (`DM4310`, `DM4340`, `DM6006`, `DM8006`, `DM8009`)
+- `--iface INTERFACE`: CAN interface (default: `can0`)
+- `slave_id`: Motor ID for commands
+- `master_id`: Master ID for responses
+
+**Available Commands:**
+
+- `enable/disable`: Motor power control
+- `set-zero`: Set current position as zero
+- `refresh`: Get current motor state
+- `control`: MIT, position/velocity, velocity, or position/force control
+- `param get/set`: Read/write motor parameters
+- `save`: Save parameters to flash memory
+
+### Register Dump
+Reads all configuration registers from all motors on all busses
+
+(coming soon)
+
+## Running Anvil's Experimental Demos
+
+All of these demos are still in the early prototype & experimental stage. Please expect bugs or other unexpected behavior.
+
+### Gravity Compensation Demo
+
+Navigate to the `openarm` directory and run the gravity compensation demo using leader arms:
+
+```bash
+python -m openarm.damiao.gravity --port leader_l:left --port leader_r:right
+```
+
+This command enables gravity compensation on the leader arms, allowing them to be moved freely by hand and stay in position without falling due to gravity.
+
+For more information: `python -m openarm.damiao.gravity --help`
+
+**Options:**
+
+- `--port INTERFACE:POSITION`: Specify CAN interface and arm position
+  - `POSITION` must be `left` or `right`
+  - Can specify multiple `--port` arguments
+
+### Leader-Follower Teleoperation Demo (requires 2 robots)
+
+Navigate to the `openarm` directory and run the teleoperation demo using leader and follower arms:
+
+```bash
+python -m openarm.damiao.monitor -t --gravity \
+  --follow leader_l:left:follower_l:left \
+  --follow leader_r:right:follower_r:right
+```
+
+This command runs the leader arms with gravity compensation and makes the follower arms mirror the leader arms' movements in real time.
+
+For more information: `python -m openarm.damiao.monitor --help`
+
+**Options:**
+
+- `-t, --teleop`: Enable teleoperation mode
+- `--follow MASTER:POS:SLAVE:POS`: Define master-slave mappings
+  - `POS` is `left` or `right` (determines arm position)
+  - Mirror mode auto-enabled when positions differ (e.g., `left` master → `right` slave)
+- `-g, --gravity`: Enable gravity compensation for master arms
+- `-v, --velocity SPEED`: Velocity for slave motors (default: 1.0)
+
+
+## Running Enactic's OpenArm Demos
+The Enactic team has released several repositories and demos that work on the open arm. You can follow our guide for building and running the Enactic's software ([Using Enactic's Stack](enactic.md)), or you can refer directly to the Enactic GitHub (https://github.com/enactic/openarm).
+
+*Please note that Enactic is unaffiliated with Anvil Robotics.*
+
+## ☠️ Danger-Zone - Changing the Motor Configurations ☠️
+*The following tools can flash new configuration parameters to motors. Doing any of the following may result in the motors no longer being able to effectively communicate with the linux host.*
 
 ### Motor Configuration
 
@@ -76,16 +234,6 @@ python -m openarm.damiao.configure --channel can0 --set-motor J1 --set-master 0x
 - Motors are auto-detected on the specified channel
 - The script assumes DM8009 motor type by default
 
-### CAN Interface Setup (Linux only)
-
-Before using any motor control commands, you need to set up the CAN interfaces:
-
-```bash
-sudo ./scripts/setup_can.sh left_arm right_arm
-```
-
-This script configures the CAN devices with the specified interface names and sets the bitrate to 1 Mbps. Interface names are provided as command-line arguments. You only need to run this script once—afterwards, whenever the CAN devices are replugged or the computer is restarted, they will be set up automatically.
-
 ### Zero Position Calibration
 
 Set all motors to zero position automatically across all detected CAN buses:
@@ -97,103 +245,3 @@ python -m openarm.damiao.set_zero
 # Specify custom CAN interface (Linux only)
 python -m openarm.damiao.set_zero --interface can1
 ```
-
-### Motor Monitoring
-
-Monitor motor angles in real-time across all detected CAN buses:
-
-```bash
-# Monitor all motors (passive mode - motors disabled)
-python -m openarm.damiao.monitor
-
-# Specify custom CAN interface (Linux only)
-python -m openarm.damiao.monitor --interface can1
-```
-
-### Direct Motor Control
-
-Low-level control of individual motors for testing and debugging:
-
-```bash
-# Enable a motor
-python -m openarm.damiao enable --motor-type DM4310 --iface can0 1 1
-
-# Control motor with MIT parameters
-python -m openarm.damiao control mit --motor-type DM4310 --iface can0 1 1 \
-    50 0.3 0 0 0  # kp kd q dq tau
-
-# Position/velocity control
-python -m openarm.damiao control pos_vel --motor-type DM4310 --iface can0 1 1 \
-    1.57 2.0  # position(rad) velocity(rad/s)
-
-# Get motor status
-python -m openarm.damiao refresh --motor-type DM4310 --iface can0 1 1
-
-# Get/set motor parameters
-python -m openarm.damiao param get --motor-type DM4310 --iface can0 1 1 over_voltage
-python -m openarm.damiao param set --motor-type DM4310 --iface can0 1 1 max_speed 10.0
-
-# Disable motor safely
-python -m openarm.damiao disable --motor-type DM4310 --iface can0 1 1
-```
-
-**Common Arguments:**
-
-- `--motor-type TYPE`: Motor type (`DM4310`, `DM4340`, `DM6006`, `DM8006`, `DM8009`)
-- `--iface INTERFACE`: CAN interface (default: `can0`)
-- `slave_id`: Motor ID for commands
-- `master_id`: Master ID for responses
-
-**Available Commands:**
-
-- `enable/disable`: Motor power control
-- `set-zero`: Set current position as zero
-- `refresh`: Get current motor state
-- `control`: MIT, position/velocity, velocity, or position/force control
-- `param get/set`: Read/write motor parameters
-- `save`: Save parameters to flash memory
-
-### Gravity Compensation
-
-Run physics-based gravity compensation on specific arms:
-
-```bash
-# Single arm gravity compensation
-python -m openarm.damiao.gravity --port can0:left
-
-# Multiple arms simultaneously
-python -m openarm.damiao.gravity --port can0:left --port can1:right
-```
-
-**Options:**
-
-- `--port INTERFACE:POSITION`: Specify CAN interface and arm position
-  - `POSITION` must be `left` or `right`
-  - Can specify multiple `--port` arguments
-
-### Teleoperation
-
-Enable teleoperation where master arms control slave arms in real-time:
-
-```bash
-# Basic teleoperation (first bus masters others)
-python -m openarm.damiao.monitor --teleop
-
-# Custom master-slave with automatic mirror detection
-python -m openarm.damiao.monitor -t --follow can0:left:can1:right
-
-# Multiple master-slave pairs
-python -m openarm.damiao.monitor -t --follow can1:left:can2:right --follow can0:right:can3:left
-
-# With gravity compensation and custom velocity
-python -m openarm.damiao.monitor -t --follow can1:left:can2:right --gravity --velocity 5
-```
-
-**Options:**
-
-- `-t, --teleop`: Enable teleoperation mode
-- `--follow MASTER:POS:SLAVE:POS`: Define master-slave mappings
-  - `POS` is `left` or `right` (determines arm position)
-  - Mirror mode auto-enabled when positions differ (e.g., `left` master → `right` slave)
-- `-g, --gravity`: Enable gravity compensation for master arms
-- `-v, --velocity SPEED`: Velocity for slave motors (default: 1.0)

--- a/enactic.md
+++ b/enactic.md
@@ -1,0 +1,118 @@
+# Using Enactic's Stack
+
+Enactic's stack is a C++-based control system for OpenArm robots.
+
+## Setup
+
+### Install Dependencies
+
+Install the following dependencies required to compiles Enactic's stack:
+
+```bash
+sudo apt install cmake g++ libeigen3-dev liborocos-kdl-dev liburdfdom-dev liburdfdom-headers-dev libyaml-cpp-dev
+```
+
+### 1. Compiling OpenArm CAN Project
+
+Clone the project and navigate into it:
+
+```bash
+git clone https://github.com/enactic/openarm_can.git
+cd openarm_can
+```
+
+Build and install the project to the system:
+
+```bash
+cmake -B build -D CMAKE_BUILD_TYPE=Release
+cmake --build build
+sudo cmake --install build
+```
+
+### 2. Compiling KDL Parser Project
+
+Make sure SSH Key is already set up in GitHub (see [setup guide](./setup.md#setup-ssh-key-in-github)), then clone the project and navigate into it:
+
+```bash
+git clone git@github.com:anvil-robotics/kdl-parser.git
+cd kdl-parser
+```
+
+Build and install the project to the system:
+
+```bash
+cmake -B build -D CMAKE_BUILD_TYPE=Release
+cmake --build build
+sudo cmake --install build
+```
+
+### 3. Compiling OpenArm Teleop Project
+
+Clone the project and navigate into it:
+
+```bash
+git clone https://github.com/enactic/openarm_teleop.git
+cd openarm_teleop
+```
+
+Build the project (note: this project is **not** installed to the system):
+
+```bash
+cmake -B build -D CMAKE_BUILD_TYPE=Release
+cmake --build build
+```
+
+### 4. Preparing OpenArm URDF
+
+Navigate to the `openarm_teleop` project directory and download the URDF file for the teleoperation demos:
+
+```bash
+curl -L -o openarm_bimanual.urdf https://gist.githubusercontent.com/threeal/d499e9d3e0be398bf9d030b7f3df970a/raw/08100a0ca3bcb360bd9d06822981d8a0d5a19d65/openarm_bimanual.urdf
+```
+
+Alternatively, you can generate the URDF file by following the [official guide](https://docs.openarm.dev/software/description/).
+
+## Running the Demos
+
+**Prerequisites** - Before running any demo:
+
+1. All robots are **powered on** and connected via USB-CAN devices
+2. All robots are placed in their **resting position**
+3. USB-CAN devices are properly configured with persistent names (see [setup guide](./setup.md#configure-usb-can-devices))
+4. OpenArm Teleop project is **built successfully** and URDF file is **prepared**
+
+### Gravity Compensation Demo
+
+Navigate to the `openarm_teleop` directory. You'll need **two terminals** to run both arms simultaneously.
+
+**Terminal 1** - Left leader arm:
+```bash
+build/gravity_comp left_arm leader_l openarm_bimanual.urdf
+```
+
+**Terminal 2** - Right leader arm:
+```bash
+build/gravity_comp right_arm leader_r openarm_bimanual.urdf
+```
+
+This enables gravity compensation on the leader arms, allowing them to be moved freely by hand and stay in position without falling due to gravity.
+
+For more information: `build/gravity_comp --help`
+
+### Leader–Follower Teleoperation Demo
+
+Navigate to the `openarm_teleop` directory. You'll need **two terminals** to control both arm pairs simultaneously.
+
+**Terminal 1** - Left arm pair:
+```bash
+build/bilateral_control openarm_bimanual.urdf openarm_bimanual.urdf left_arm leader_l follower_l
+```
+
+**Terminal 2** - Right arm pair:
+```bash
+build/bilateral_control openarm_bimanual.urdf openarm_bimanual.urdf right_arm leader_r follower_r
+```
+
+This runs the leader arms with gravity compensation and makes the follower arms mirror the leader arms' movements in real time.
+
+For more information: `build/bilateral_control --help`


### PR DESCRIPTION
We had a bunch of redundant docs in multiple repos, which made it hard for people to actually start using this repo. This PR does the following:

* Pulls in all documentation that was in Anvil's 'quickstart' repo. (Thus, the `quikstart` repo will now be deprecated )
* Removes any redundant sections that were already in the `README.md`
* Provides a more linear flow, with the hopes of making setup easier for users.