### PR TITLE
Use GitHub-hosted runner for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,29 +7,29 @@ on:
 jobs:
   build-package:
     name: Build Package
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v5.0.0
 
-      - name: Setup Virtual Environment
-        run: |
-          rm -rf .venv
-          python3 -m venv .venv
+      - name: Setup Python
+        uses: actions/setup-python@v6.0.0
+        with:
+          python-version: 3.11
 
       - name: Install Dependencies
         run: |
-          .venv/bin/pip install -e .
-          .venv/bin/pip install build pytest ruff
+          pip install -e .
+          pip install build pytest ruff
 
       - name: Test Package
-        run: .venv/bin/pytest
+        run: pytest
 
       - name: Check Formatting
-        run: $HOME/.dprint/bin/dprint check
+        uses: dprint/check@v2.3
 
       - name: Check Lint
-        run: .venv/bin/ruff check
+        run: ruff check
 
       - name: Build Package
-        run: .venv/bin/python -m build
+        run: python -m build


### PR DESCRIPTION
Modify the `ci.yaml` GitHub Action workflow to use GitHub-hosted runner, reverting #35.