### PR TITLE
Fix commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,24 +113,24 @@ Low-level control of individual motors for testing and debugging:
 
 ```bash
 # Enable a motor
-python -m openarm.damiao enable --motor-type DM4310 --iface follower_l 1 1
+python -m openarm.damiao enable --motor-type DM4310 --iface follower_l 1 17
 
 # Set MIT Mode and Command motor with MIT parameters
-python -m openarm.damiao param set --motor-type DM8009 --iface follower_l 1 17 control_mode 1
-python -m openarm.damiao control mit --motor-type DM4310 --iface follower_l 1 1 50 0.3 0 0 0  # kp kd q dq tau
+python -m openarm.damiao param set --motor-type DM4310 --iface follower_l 1 17 control_mode 1
+python -m openarm.damiao control mit --motor-type DM4310 --iface follower_l 1 1 5 0.3 0 0 0  # kp kd q dq tau
 
 # Set PosVel control mode and Command motor with PosVel command
-python -m openarm.damiao param set --motor-type DM8009 --iface follower_l 1 17 control_mode 2
-python -m openarm.damiao control pos_vel --motor-type DM4310 --iface follower_l 1 1 1.57 2.0  # position(rad) velocity(rad/s)
+python -m openarm.damiao param set --motor-type DM4310 --iface follower_l 1 17 control_mode 2
+python -m openarm.damiao control pos_vel --motor-type DM4310 --iface follower_l 1 17 1.57 2.0  # position(rad) velocity(rad/s)
 
 # Get motor status
-python -m openarm.damiao refresh --motor-type DM4310 --iface follower_l 1 1
+python -m openarm.damiao refresh --motor-type DM4310 --iface follower_l 1 17
 
 # Get motor parameters
-python -m openarm.damiao param get --motor-type DM4310 --iface follower_l 1 1 over_voltage
+python -m openarm.damiao param get --motor-type DM4310 --iface follower_l 1 17 over_voltage
 
 # Disable motor safely
-python -m openarm.damiao disable --motor-type DM4310 --iface follower_l 1 1
+python -m openarm.damiao disable --motor-type DM4310 --iface follower_l 1 17
 ```
 
 **Common Arguments:**


### PR DESCRIPTION
- Fix inconsistent motor types in Direct Motor Control commands
- Fix inconsistent master IDs in Direct Motor Control commands
- Change MIT mode Kp gain from 50 to 5. A gain of 50 with the DM4310 causes the motor to vibrate rapidly when used on a benchtop