### PR TITLE
Fix: update motor-testing doc to prevent left arm J2 reach joint limit and hitting pedestal

### DIFF
--- a/motor-testing.md
+++ b/motor-testing.md
@@ -54,12 +54,17 @@ python -m openarm.damiao disable --motor-type DM8009 --iface follower_l 1 17
 
 #### J2 (DM8009)
 
+**Safety Note**: J2 movement direction is critical to avoid collision with the pedestal.
+- **Left arm (`follower_l`)**: Use **-0.15 rad** to move away from pedestal (safe direction)
+- **Right arm (`follower_r`)**: Use **+0.15 rad** to move away from pedestal (safe direction)
+
 ```bash
 python -m openarm.damiao enable --motor-type DM8009 --iface follower_l 2 18
 python -m openarm.damiao param set --motor-type DM8009 --iface follower_l 2 18 control_mode 2
 python -m openarm.damiao control pos_vel --motor-type DM8009 --iface follower_l 2 18 0.0 0.2
 sleep 2
-python -m openarm.damiao control pos_vel --motor-type DM8009 --iface follower_l 2 18 0.3 0.2
+# Safety Note: please ensure the arm is moving away from the pedestal for safety
+python -m openarm.damiao control pos_vel --motor-type DM8009 --iface follower_l 2 18 -0.15 0.15
 sleep 2
 python -m openarm.damiao control pos_vel --motor-type DM8009 --iface follower_l 2 18 0.0 0.2
 sleep 2

--- a/motor-testing.md
+++ b/motor-testing.md
@@ -66,7 +66,7 @@ python -m openarm.damiao param set --motor-type DM8009 --iface follower_l 2 18 c
 python -m openarm.damiao control pos_vel --motor-type DM8009 --iface follower_l 2 18 0.0 0.2
 sleep 2
 # Safety Note: please ensure the arm is moving away from the pedestal for safety
-python -m openarm.damiao control pos_vel --motor-type DM8009 --iface follower_l 2 18 -0.15 0.15
+python -m openarm.damiao control pos_vel --motor-type DM8009 --iface follower_l 2 18 -0.15 0.2
 sleep 2
 python -m openarm.damiao control pos_vel --motor-type DM8009 --iface follower_l 2 18 0.0 0.2
 sleep 2

--- a/motor-testing.md
+++ b/motor-testing.md
@@ -56,8 +56,9 @@ python -m openarm.damiao disable --motor-type DM8009 --iface follower_l 1 17
 
 > [!CAUTION]
 > J2 movement direction is critical to avoid collision with the pedestal.
-> - Left arm (`follower_l`, `robot_l`): Use -0.15 rad to move away from pedestal (safe direction)
-> - Right arm (`follower_r`, `robot_r`): Use +0.15 rad to move away from pedestal (safe direction)
+>
+> Left arm (`follower_l`, `robot_l`): Use -0.15 rad to move away from pedestal (safe direction)
+> Right arm (`follower_r`, `robot_r`): Use +0.15 rad to move away from pedestal (safe direction)
 
 ```bash
 python -m openarm.damiao enable --motor-type DM8009 --iface follower_l 2 18

--- a/motor-testing.md
+++ b/motor-testing.md
@@ -54,10 +54,10 @@ python -m openarm.damiao disable --motor-type DM8009 --iface follower_l 1 17
 
 #### J2 (DM8009)
 
-**Safety Note**: J2 movement direction is critical to avoid collision with the pedestal.
-
-- **Left arm (`follower_l`)**: Use **-0.15 rad** to move away from pedestal (safe direction)
-- **Right arm (`follower_r`)**: Use **+0.15 rad** to move away from pedestal (safe direction)
+> [!CAUTION]
+> J2 movement direction is critical to avoid collision with the pedestal.
+> - Left arm (`follower_l`, `robot_l`): Use -0.15 rad to move away from pedestal (safe direction)
+> - Right arm (`follower_r`, `robot_r`): Use +0.15 rad to move away from pedestal (safe direction)
 
 ```bash
 python -m openarm.damiao enable --motor-type DM8009 --iface follower_l 2 18

--- a/motor-testing.md
+++ b/motor-testing.md
@@ -55,6 +55,7 @@ python -m openarm.damiao disable --motor-type DM8009 --iface follower_l 1 17
 #### J2 (DM8009)
 
 **Safety Note**: J2 movement direction is critical to avoid collision with the pedestal.
+
 - **Left arm (`follower_l`)**: Use **-0.15 rad** to move away from pedestal (safe direction)
 - **Right arm (`follower_r`)**: Use **+0.15 rad** to move away from pedestal (safe direction)
 


### PR DESCRIPTION
# Issue
[[AHT-370] J2 on left follower arm mote towards pedestal](https://www.notion.so/anvil-robotics/openarm-repo-Motor-testing-guide-J2-on-a-left-follower-arm-moved-the-unsafe-way-29a8f2efe5658072a48effc2d7538a41?source=copy_link)

# Description
Running the following command will cause the arm to move towards pedestal and reached the joint limit of 0.175 rad.

```bash
python -m openarm.damiao control pos_vel --motor-type DM8009 --iface follower_l 2 18 0.3 0.2
```

# Changes
Changed the direction to -0.15 (rad), slow down the moving speed to 0.15(rad/s) and added some notes to warm reader.

```bash
# Safety Note: please ensure the arm is moving away from the pedestal for safety
python -m openarm.damiao control pos_vel --motor-type DM8009 --iface follower_l 2 18 -0.15 0.15
```

# Testing
Plug onto any OpenArm and run the testing command.

The video below demonstrate the expected moving direction with right arm, although this fix is for left arm.

https://github.com/user-attachments/assets/2518fc2c-f727-4f60-acf8-61a4ed83d43e